### PR TITLE
improvement: KG Improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,6 @@ ENV=dev
 PAPER_FOLDER="papers"
 # Use Google Drive for papers (true/false)
 USE_GOOGLE_DRIVE=false
+
+# Optional - email for science APIs such as crossRef
+EMAIL="your_email_here"

--- a/src/bioagentPlugin/science-api-helper.ts
+++ b/src/bioagentPlugin/science-api-helper.ts
@@ -1,0 +1,267 @@
+import axios from "axios";
+import { z, ZodTypeAny } from "zod";
+import { logger } from "@elizaos/core";
+
+// Define the Zod schema for a single citation
+export const CitationSchema = z.object({
+  "@id": z
+    .string()
+    .url() // Ensure it's a URL
+    .describe(
+      "A unique identifier (often a DOI) for the cited work being referenced, e.g., https://doi.org/10.1016/j.cell.2005.05.012."
+    ),
+  "@type": z
+    .literal("bibo:AcademicArticle") // Explicitly set to 'bibo:AcademicArticle'
+    .optional()
+    .describe("RDF type of the cited resource, always 'bibo:AcademicArticle'"),
+  "dcterms:title": z
+    .string()
+    .describe("Title of the cited work or resource.")
+    .nullable(), // Title might not always be available
+  "bibo:doi": z
+    .string()
+    .optional()
+    .describe(
+      "Explicit DOI string of the cited work, e.g. '10.1038/s41586-020-XXXXX'."
+    ),
+});
+
+// Zod schema for an array of citations
+export const CitationsArraySchema = z.array(CitationSchema);
+
+/**
+ * Attempts to retrieve the DOI (as a full URL) for a given paper title.
+ * It tries Crossref first, then Semantic Scholar.
+ *
+ * @param title The title of the paper.
+ * @param email Your email address for API "polite pool" usage.
+ * @returns A Promise that resolves with the full DOI URL (e.g., "https://doi.org/...") if found, or null otherwise.
+ */
+export async function getDoiFromTitle(
+  title: string,
+  email: string | null
+): Promise<string | null> {
+  // --- Try Crossref API first ---
+  try {
+    const crossrefUrl = "https://api.crossref.org/works";
+    const crossrefParams = {
+      "query.title": title,
+      rows: 1,
+      mailto: email,
+    };
+
+    const response = await axios.get(crossrefUrl, {
+      params: crossrefParams,
+    });
+
+    if (
+      response.data &&
+      response.data.message &&
+      response.data.message.items &&
+      response.data.message.items.length > 0
+    ) {
+      const firstResult = response.data.message.items[0];
+      if (firstResult.DOI) {
+        return `https://doi.org/${firstResult.DOI}`; // Return full URL
+      }
+    }
+  } catch (error) {
+    logger.warn(
+      `Crossref API (title search) failed for "${title}":`,
+      axios.isAxiosError(error) ? error.message : error
+    );
+  }
+
+  // --- If Crossref fails, try Semantic Scholar API ---
+  logger.info("Crossref did not find DOI, trying Semantic Scholar...");
+  try {
+    const semanticScholarUrl =
+      "https://api.semanticscholar.org/graph/v1/paper/search";
+    const semanticScholarParams = {
+      query: title,
+      fields: "title,externalIds", // Request title and externalIds (where DOI is)
+    };
+    const headers = {
+      "User-Agent": `YourAppName/1.0 (mailto:${email})`,
+    };
+
+    const response = await axios.get(semanticScholarUrl, {
+      params: semanticScholarParams,
+      headers: headers,
+    });
+
+    if (response.data && response.data.data && response.data.data.length > 0) {
+      const firstResult = response.data.data[0];
+      if (firstResult.externalIds && firstResult.externalIds.DOI) {
+        return `https://doi.org/${firstResult.externalIds.DOI}`; // Return full URL
+      }
+    }
+  } catch (error) {
+    logger.warn(
+      `Semantic Scholar API (title search) failed for "${title}":`,
+      axios.isAxiosError(error) ? error.message : error
+    );
+  }
+
+  return null; // DOI not found via any method
+}
+
+/**
+ * Fetches all references (papers cited BY the given DOI) from multiple APIs
+ * and combines them into a unique list conforming to CitationSchema.
+ *
+ * @param doi The DOI of the paper to get references from.
+ * @param email Your email address for API "polite pool" usage.
+ * @returns A Promise that resolves with an array of CitationSchema objects.
+ */
+export async function getReferencesFromDoi(
+  doi: string,
+  email: string | null
+): Promise<z.infer<typeof CitationsArraySchema>> {
+  const allReferences: { [key: string]: z.infer<typeof CitationSchema> } = {}; // Use a map to deduplicate by DOI
+
+  // Helper to add a reference to the map if it has a DOI
+  const addReference = (
+    refDoi: string | null | undefined,
+    title: string | null | undefined
+  ) => {
+    if (refDoi) {
+      const fullDoiUrl = `https://doi.org/${refDoi}`;
+
+      // Check if the URL is valid
+      try {
+        new URL(fullDoiUrl);
+
+        // Only add if not already present or if the new one has a better title
+        if (
+          !allReferences[fullDoiUrl] ||
+          (title && !allReferences[fullDoiUrl]["dcterms:title"])
+        ) {
+          allReferences[fullDoiUrl] = {
+            "@id": fullDoiUrl,
+            "@type": "bibo:AcademicArticle",
+            "dcterms:title": title || null,
+            "bibo:doi": refDoi,
+          };
+        }
+      } catch (error) {
+        logger.warn(`Invalid URL generated from DOI: ${fullDoiUrl}`);
+      }
+    }
+  };
+
+  // --- 1. Get references from Crossref API ---
+  try {
+    const crossrefUrl = `https://api.crossref.org/works/${doi}`;
+    const crossrefParams = {
+      mailto: email,
+    };
+    const response = await axios.get(crossrefUrl, {
+      params: crossrefParams,
+    });
+
+    if (
+      response.data &&
+      response.data.message &&
+      response.data.message.reference &&
+      response.data.message.reference.length > 0
+    ) {
+      response.data.message.reference.forEach((ref: any) => {
+        // Crossref references can be messy, prioritize DOI
+        const refTitle = Array.isArray(ref.title)
+          ? ref.title[0]
+          : ref.unstructured;
+        addReference(ref.DOI, refTitle);
+      });
+      logger.info(
+        `Found ${response.data.message.reference.length} references from Crossref.`
+      );
+    } else {
+      logger.info(`No references found for ${doi} from Crossref.`);
+    }
+  } catch (error) {
+    logger.warn(
+      `Crossref API (references) failed for "${doi}":`,
+      axios.isAxiosError(error) ? error.message : error
+    );
+  }
+
+  // --- 2. Get references from Semantic Scholar API ---
+  try {
+    const semanticScholarUrl = `https://api.semanticscholar.org/graph/v1/paper/DOI:${doi}`;
+    const semanticScholarParams = {
+      fields: "references.externalIds,references.title",
+    };
+    const headers = {
+      "User-Agent": `YourAppName/1.0 (mailto:${email})`,
+    };
+
+    const response = await axios.get(semanticScholarUrl, {
+      params: semanticScholarParams,
+      headers: headers,
+    });
+
+    if (
+      response.data &&
+      response.data.references &&
+      response.data.references.length > 0
+    ) {
+      response.data.references.forEach((ref: any) => {
+        addReference(ref.externalIds?.DOI, ref.title);
+      });
+      logger.info(
+        `Found ${response.data.references.length} references from Semantic Scholar.`
+      );
+    } else {
+      logger.info(`No references found for ${doi} from Semantic Scholar.`);
+    }
+  } catch (error) {
+    logger.warn(
+      `Semantic Scholar API (references) failed for "${doi}":`,
+      axios.isAxiosError(error) ? error.message : error
+    );
+  }
+
+  // --- 3. Get references from OpenCitations API ---
+  try {
+    const opencitationsUrl = `https://opencitations.net/index/api/v1/references/${doi}`;
+    const response = await axios.get(opencitationsUrl);
+
+    if (response.data && response.data.length > 0) {
+      // OpenCitations `references` endpoint returns items where `cited` is the DOI of the reference
+      for (const item of response.data) {
+        if (item.cited) {
+          // OpenCitations provides *only* the DOI. We'd need another API call
+          // to get the title if not already found. For now, add with null title.
+
+          // TODO: get title from OpenCitations, but unsure about API limits
+          addReference(item.cited, null);
+        }
+      }
+      logger.info(
+        `Found ${response.data.length} references from OpenCitations.`
+      );
+    } else {
+      logger.info(`No references found for ${doi} from OpenCitations.`);
+    }
+  } catch (error) {
+    logger.warn(
+      `OpenCitations API (references) failed for "${doi}":`,
+      axios.isAxiosError(error) ? error.message : error
+    );
+  }
+
+  // Convert the map of unique references back to an array
+  const uniqueReferences = Object.values(allReferences);
+
+  // Validate and return
+  try {
+    return CitationsArraySchema.parse(uniqueReferences);
+  } catch (validationError) {
+    logger.error(
+      "Zod validation failed for combined references:",
+      validationError
+    );
+    return []; // Return empty array on validation failure
+  }
+}

--- a/src/bioagentPlugin/services/gdrive/buildQuery.ts
+++ b/src/bioagentPlugin/services/gdrive/buildQuery.ts
@@ -17,7 +17,8 @@ class SharedDriveFolderStrategy implements ListFilesQueryStrategy {
     return {
       q: `'${this.sharedDriveFolderId}' in parents and mimeType='application/pdf' and trashed=false`,
       fields: "files(id, name, md5Checksum, size)",
-      orderBy: "name",
+      orderBy: "createdTime desc",
+      pageSize: 1000,
     };
   }
 
@@ -43,12 +44,14 @@ class SharedDriveStrategy implements ListFilesQueryStrategy {
   buildQuery(): Record<string, any> {
     return {
       q: `'${this.sharedDriveId}' in parents and mimeType='application/pdf' and trashed=false`,
-      orderBy: "name",
-      fields: "files(id, name, md5Checksum, size)",
+      orderBy: "createdTime desc",
+      fields: "files(id, name, md5Checksum, size), nextPageToken",
       supportsAllDrives: true,
       includeItemsFromAllDrives: true,
       driveId: this.sharedDriveId,
       corpora: "drive",
+      pageSize: 1000,
+      pageToken: undefined, // Will be populated with nextPageToken for subsequent requests
     };
   }
 

--- a/src/bioagentPlugin/services/gdrive/extract/config.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/config.ts
@@ -23,6 +23,7 @@ export default class Config {
     width: 595,
     height: 842,
   };
+  private static _email: string = process.env.EMAIL || null;
 
   private constructor() {}
 
@@ -128,5 +129,10 @@ export default class Config {
   public static get instructorAnthropic() {
     this.getInstance();
     return this._instructorAnthropic;
+  }
+
+  public static get email() {
+    this.getInstance();
+    return this._email;
   }
 }

--- a/src/bioagentPlugin/services/gdrive/extract/index.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/index.ts
@@ -31,38 +31,55 @@ const __dirname = path.resolve();
  * Fetches ORCID ID for an author using OpenAlex API
  */
 async function getAuthorOrcidIds(authorName: string): Promise<string | null> {
-  console.log(`[getAuthorOrcidIds] Searching for ORCID for author: ${authorName}`);
-  
+  console.log(
+    `[getAuthorOrcidIds] Searching for ORCID for author: ${authorName}`
+  );
+
   try {
-    const encodedName = encodeURIComponent(authorName.replace(/\s+/g, '+'));
+    const encodedName = encodeURIComponent(authorName.replace(/\s+/g, "+"));
     const email = process.env.EMAIL;
     const url = `https://api.openalex.org/authors?search=${encodedName}&select=orcid&mailto=${email}`;
-    
+
     const response = await fetch(url);
     if (!response.ok) {
-      console.log(`[getAuthorOrcidIds] HTTP error ${response.status} for author: ${authorName}`);
+      console.log(
+        `[getAuthorOrcidIds] HTTP error ${response.status} for author: ${authorName}`
+      );
       return null;
     }
-    
-    const data = await response.json() as { results?: { orcid: string | null }[] };
-    
+
+    const data = (await response.json()) as {
+      results?: { orcid: string | null }[];
+    };
+
     if (data.results && data.results.length > 0) {
       // Find the first result with a non-null ORCID
-      const resultWithOrcid = data.results.find((result) => result.orcid !== null);
-      
+      const resultWithOrcid = data.results.find(
+        (result) => result.orcid !== null
+      );
+
       if (resultWithOrcid && resultWithOrcid.orcid) {
-        console.log(`[getAuthorOrcidIds] ✅ Found ORCID for ${authorName}: ${resultWithOrcid.orcid}`);
+        console.log(
+          `[getAuthorOrcidIds] ✅ Found ORCID for ${authorName}: ${resultWithOrcid.orcid}`
+        );
         return resultWithOrcid.orcid;
       } else {
-        console.log(`[getAuthorOrcidIds] ⚠️ No ORCID found for author: ${authorName}`);
+        console.log(
+          `[getAuthorOrcidIds] ⚠️ No ORCID found for author: ${authorName}`
+        );
         return null;
       }
     } else {
-      console.log(`[getAuthorOrcidIds] ⚠️ No results found for author: ${authorName}`);
+      console.log(
+        `[getAuthorOrcidIds] ⚠️ No results found for author: ${authorName}`
+      );
       return null;
     }
   } catch (error) {
-    console.log(`[getAuthorOrcidIds] ❌ Error fetching ORCID for ${authorName}:`, error);
+    console.log(
+      `[getAuthorOrcidIds] ❌ Error fetching ORCID for ${authorName}:`,
+      error
+    );
     return null;
   }
 }
@@ -198,8 +215,7 @@ async function validateOntologyTerms(ontologies: any) {
           }
           validatedCount++;
 
-          // Add schema:url field
-          term["schema:url"] = fullUrl;
+          term["@id"] = fullUrl;
         }
       } else if (
         originalId.startsWith("DOID:") ||
@@ -218,8 +234,7 @@ async function validateOntologyTerms(ontologies: any) {
           }
           validatedCount++;
 
-          // Add schema:url field
-          term["schema:url"] = fullUrl;
+          term["@id"] = fullUrl;
         }
       } else if (
         originalId.startsWith("CHEBI:") ||
@@ -238,8 +253,7 @@ async function validateOntologyTerms(ontologies: any) {
           }
           validatedCount++;
 
-          // Add schema:url field
-          term["schema:url"] = fullUrl;
+          term["@id"] = fullUrl;
         }
       } else if (
         originalId.startsWith("ATC:") ||
@@ -256,8 +270,7 @@ async function validateOntologyTerms(ontologies: any) {
           }
           validatedCount++;
 
-          // Add schema:url field
-          term["schema:url"] = fullUrl;
+          term["@id"] = fullUrl;
         }
       } else if (
         originalId.startsWith("MONDO:") ||
@@ -276,8 +289,7 @@ async function validateOntologyTerms(ontologies: any) {
           }
           validatedCount++;
 
-          // Add schema:url field
-          term["schema:url"] = fullUrl;
+          term["@id"] = fullUrl;
         }
       } else if (
         originalId.startsWith("ECO:") ||
@@ -294,8 +306,7 @@ async function validateOntologyTerms(ontologies: any) {
           }
           validatedCount++;
 
-          // Add schema:url field
-          term["schema:url"] = fullUrl;
+          term["@id"] = fullUrl;
         }
       } else if (originalId.startsWith("PW:") || originalId.startsWith("pw:")) {
         // Assuming CURIE for Pathway Ontology is PW:XXXXXXX
@@ -312,8 +323,7 @@ async function validateOntologyTerms(ontologies: any) {
           }
           validatedCount++;
 
-          // Add schema:url field
-          term["schema:url"] = fullUrl;
+          term["@id"] = fullUrl;
         }
       } else if (
         originalId.startsWith("MESH:") ||
@@ -332,8 +342,7 @@ async function validateOntologyTerms(ontologies: any) {
           }
           validatedCount++;
 
-          // Add schema:url field
-          term["schema:url"] = fullUrl;
+          term["@id"] = fullUrl;
         }
       } else {
         console.log(
@@ -344,10 +353,7 @@ async function validateOntologyTerms(ontologies: any) {
         validatedCount++;
       }
 
-      validatedTerms.push({
-        ...term,
-        "@id": validatedId, // Update with the new full URI
-      });
+      validatedTerms.push(term);
 
       if (wasUpdated && validatedId !== originalId) {
         // Check validatedId !== originalId again because wasUpdated might be true even if strings are same due to normalization logic
@@ -470,23 +476,29 @@ export async function generateKa(
   // Process authors and update their ORCID IDs
   console.log(`[generateKa] Processing authors to get ORCID IDs`);
   const extractedAuthors = res[0]["dcterms:creator"] || [];
-  
+
   for (const author of extractedAuthors) {
     const authorName = author["foaf:name"];
     if (authorName) {
       console.log(`[generateKa] Processing author: ${authorName}`);
       const orcidId = await getAuthorOrcidIds(authorName);
-      
+
       if (orcidId) {
         author["@id"] = orcidId;
-        console.log(`[generateKa] ✅ Updated author ${authorName} with ORCID: ${orcidId}`);
+        console.log(
+          `[generateKa] ✅ Updated author ${authorName} with ORCID: ${orcidId}`
+        );
       } else {
-        console.log(`[generateKa] ⚠️ Keeping original @id for author: ${authorName}`);
+        console.log(
+          `[generateKa] ⚠️ Keeping original @id for author: ${authorName}`
+        );
       }
     }
   }
-  
-  console.log(`[generateKa] Processed ${extractedAuthors.length} authors for ORCID IDs`);
+
+  console.log(
+    `[generateKa] Processed ${extractedAuthors.length} authors for ORCID IDs`
+  );
 
   const paperTitle = res[0]["dcterms:title"];
   const llmExtractedDoi = res[0]["@id"];

--- a/src/bioagentPlugin/services/gdrive/extract/index.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/index.ts
@@ -13,6 +13,8 @@ async function extractPaper(images: OpenAIImage[]) {
   );
   const client = Config.instructorOai;
 
+  // TODO: aside of images we could get some data from the internet or OpenAlex, like citations
+
   const { _meta, ...paper } = await client.chat.completions.create({
     model: "gpt-4o",
     messages: [
@@ -50,12 +52,15 @@ async function extractOntologies(images: OpenAIImage[]) {
         content: [...images],
       },
     ],
+    // TODO: this is incorrect, 'ontologies' doesn't belong to any ontology
     response_model: { schema: OntologiesSchema, name: "Ontologies" },
     max_retries: 3,
   });
   console.log(
     `[extractOntologies] Ontologies extraction completed successfully`
   );
+
+  // TODO: check if the ontologies match to real world examples, consider using a model with search
   return ontologies;
 }
 
@@ -69,7 +74,7 @@ export async function categorizeIntoDAOsString(abstract: string) {
     messages: [
       {
         role: "system",
-        content: categorizeIntoDAOsPrompt
+        content: categorizeIntoDAOsPrompt,
       },
       {
         role: "user",
@@ -93,7 +98,13 @@ export async function generateKa(images: OpenAIImage[]) {
   res[0]["ontologies"] = res[1]["ontologies"];
   console.log(`[generateKa] Knowledge extraction successfully completed`);
 
-  const relatedDAOsString = await categorizeIntoDAOsString([res[0]["dcterms:abstract"], res[0]["dcterms:title"], JSON.stringify(res[0]["schema:keywords"])].join("\n"));
+  const relatedDAOsString = await categorizeIntoDAOsString(
+    [
+      res[0]["dcterms:abstract"],
+      res[0]["dcterms:title"],
+      JSON.stringify(res[0]["schema:keywords"]),
+    ].join("\n")
+  );
 
   console.log(`[generateKa] Related DAOs: ${relatedDAOsString}`);
 

--- a/src/bioagentPlugin/services/gdrive/extract/prompts.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/prompts.ts
@@ -44,7 +44,8 @@ Generate a rich, diverse set of ontology terms for my scientific paper JSON-LD u
 \`\`\`json
 {
   "@id": "[PREFIX]:[ID_NUMBER]",
-  "schema:name": "[OFFICIAL_LABEL]"
+  "dcterms:name": "[OFFICIAL_LABEL]",
+  "dcterms:description": "[DESCRIPTION]"
 }
 \`\`\`
 
@@ -73,8 +74,9 @@ Include terms from these ontologies (3-5 terms from each where relevant):
 
 1. **ALL terms MUST be real and verifiable** with:
    - Correct prefix format (e.g., "GO:0008150", "DOID:14330")
-   - Genuine numeric ID (never use placeholders like "xxxx")
-   - Accurate official label as "schema:name"
+   - Genuine numeric ID (never use placeholders like "xxxx") 
+   - Accurate official label as "dcterms:name"
+   - Description of what was found regarding to that term in the paper, in "dcterms:description" field
 
 2. **Prioritize terms that are:**
    - Domain-specific rather than overly general
@@ -92,18 +94,59 @@ Include terms from these ontologies (3-5 terms from each where relevant):
 4. **DO NOT use any of the example ontology terms listed below unless they are specifically relevant to my research paper topic.** Select terms that actually apply to my research:
 
 \`\`\`json
-"cito:discusses": [
-  {"@id": "GO:0006915", "schema:name": "apoptotic process"},
-  {"@id": "GO:0007154", "schema:name": "cell communication"},
-  {"@id": "DOID:14330", "schema:name": "lung cancer"},
-  {"@id": "MONDO:0005148", "schema:name": "breast cancer"},
-  {"@id": "CHEBI:15377", "schema:name": "water"},
-  {"@id": "CHEBI:27732", "schema:name": "morphine"},
-  {"@id": "ATC:N02AA01", "schema:name": "morphine"},
-  {"@id": "PW:0000013", "schema:name": "citric acid cycle pathway"},
-  {"@id": "ECO:0000006", "schema:name": "experimental evidence"},
-  {"@id": "MESH:D015179", "schema:name": "Pre-Eclampsia"}
+"schema:about": [
+  {
+    "@id": "GO:0006915",
+    "dcterms:name": "apoptotic process",
+    "dcterms:description": "The paper discusses programmed cell death mechanisms in relation to cancer development"
+  },
+  {
+    "@id": "GO:0007154", 
+    "dcterms:name": "cell communication",
+    "dcterms:description": "The research examines intercellular signaling pathways between cancer cells"
+  },
+  {
+    "@id": "DOID:14330",
+    "dcterms:name": "lung cancer", 
+    "dcterms:description": "Study includes analysis of lung cancer progression and metastasis"
+  },
+  {
+    "@id": "MONDO:0005148",
+    "dcterms:name": "breast cancer",
+    "dcterms:description": "Research compares molecular mechanisms between breast and lung cancer types"
+  },
+  {
+    "@id": "CHEBI:15377",
+    "dcterms:name": "water",
+    "dcterms:description": "Used as control solvent in experimental procedures"
+  },
+  {
+    "@id": "CHEBI:27732",
+    "dcterms:name": "morphine",
+    "dcterms:description": "Discussed as analgesic treatment in cancer pain management"
+  },
+  {
+    "@id": "ATC:N02AA01",
+    "dcterms:name": "morphine",
+    "dcterms:description": "Referenced in context of pain management protocols"
+  },
+  {
+    "@id": "PW:0000013",
+    "dcterms:name": "citric acid cycle pathway",
+    "dcterms:description": "Analysis of metabolic changes in cancer cell energy production"
+  },
+  {
+    "@id": "ECO:0000006",
+    "dcterms:name": "experimental evidence",
+    "dcterms:description": "Type of evidence used to support key findings in the research"
+  },
+  {
+    "@id": "MESH:D015179",
+    "dcterms:name": "Pre-Eclampsia",
+    "dcterms:description": "Discussed as a complication affecting treatment options"
+  }
 ]
 \`\`\`
 
 Provide a minimum of 25-30 diverse, relevant ontology terms that would appear in the "cito:discusses" section of my scientific paper. Ensure ALL terms are genuine entries that exist in their respective ontologies and are directly related to my specific research topic.`;
+// TODO: perhaps replace schema:about with cito:discusses

--- a/src/bioagentPlugin/services/gdrive/extract/prompts.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/prompts.ts
@@ -148,5 +148,49 @@ Include terms from these ontologies (3-5 terms from each where relevant):
 ]
 \`\`\`
 
-Provide a minimum of 25-30 diverse, relevant ontology terms that would appear in the "cito:discusses" section of my scientific paper. Ensure ALL terms are genuine entries that exist in their respective ontologies and are directly related to my specific research topic.`;
+Provide a minimum of 25-30 diverse, relevant ontology terms that would appear in the "schema:about" section of my scientific paper. Ensure ALL terms are genuine entries that exist in their respective ontologies and are directly related to my specific research topic.`;
 // TODO: perhaps replace schema:about with cito:discusses
+
+export const citationsExtractionPrompt = `# Citation Extraction Prompt
+
+You are a specialized assistant that extracts citations and references from scientific papers. Focus on the References/Bibliography section, typically found at the end of papers.
+
+## **Output Format**
+
+Return exactly one JSON object with this structure:
+
+\`\`\`json
+{
+  "cito:cites": [
+    {
+      "@id": "https://doi.org/10.1016/j.cell.2005.05.012",
+      "@type": "bibo:AcademicArticle",
+      "dcterms:title": "Title of the cited work",
+      "bibo:doi": "10.1016/j.cell.2005.05.012"
+    }
+  ]
+}
+\`\`\`
+
+## **Requirements**
+
+1. **Extract ALL citations** from the reference list/bibliography section
+2. **For each citation:**
+   - **@id**: Use DOI URL if available (https://doi.org/10.xxxx), otherwise create unique identifier
+   - **@type**: Usually "bibo:AcademicArticle" or "schema:ScholarlyArticle"
+   - **dcterms:title**: Exact title of the cited work
+   - **bibo:doi**: DOI string without https://doi.org/ prefix (optional if DOI not available)
+
+3. **Quality Guidelines:**
+   - Extract titles exactly as they appear
+   - Include DOI when clearly visible in reference format
+   - Focus on academic articles, books, and formal publications
+   - Skip informal citations or incomplete references
+   - Ensure each citation has at minimum @id and dcterms:title
+
+4. **Output Requirements:**
+   - Return only the JSON object
+   - No additional commentary or markdown
+   - Must be valid JSON that matches the schema above
+
+**Your Task**: Extract all citations from the reference section and format them according to the schema above.`;

--- a/src/bioagentPlugin/services/gdrive/extract/types.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/types.ts
@@ -19,3 +19,21 @@ export type OpenAIImage = {
 };
 
 export type InstructorClient = IC<OpenAI> | IC<Anthropic>;
+
+export interface ParsedTeiXmlDocument {
+  title: string | null;
+  doi: string | null;
+  abstract: string | null;
+  introduction: string | null;
+  methods: string | null;
+  results: string | null;
+  discussion: string | null;
+  conclusion: string | null;
+  futureWork: string | null;
+  appendix: string | null;
+  citations: string | null;
+  authors: string[];
+  datePublished: string | null;
+  publisher: string | null;
+  error?: string;
+}

--- a/src/bioagentPlugin/services/gdrive/extract/z.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/z.ts
@@ -120,7 +120,7 @@ const SectionSchema = z.object({
 });
 
 // citation schema
-const CitationSchema = z.object({
+export const CitationSchema = z.object({
   "@id": z
     .string()
     .describe(

--- a/src/bioagentPlugin/services/gdrive/extract/z.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/z.ts
@@ -146,18 +146,17 @@ export const OntologyTermSchema = z.object({
   "@id": z
     .string()
     .describe(
-      "IRI of the ontology term (e.g., http://purl.obolibrary.org/obo/GO_0070765 for 'gamma secretase activity')."
+      "Short form of the ontology term (e.g., 'MONDO_0004975', 'GO_0070765')."
     ),
   "dcterms:name": z
     .string()
     .describe(
       "Human-readable label of the ontology term (e.g., 'gamma secretase activity')."
     ),
-  "dcterms:title": z
+  "schema:url": z
     .string()
-    .optional()
     .describe(
-      "Title of the ontology term, typically used for disease or chemical entities."
+      "Full URL path to the ontology term (e.g., 'http://purl.obolibrary.org/obo/GO_0070765')."
     ),
   "dcterms:description": z
     .string()

--- a/src/bioagentPlugin/services/gdrive/extract/z.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/z.ts
@@ -148,17 +148,10 @@ export const OntologyTermSchema = z.object({
     .describe(
       "IRI of the ontology term (e.g., http://purl.obolibrary.org/obo/GO_0070765 for 'gamma secretase activity')."
     ),
-  "schema:name": z
-    .string()
-    .optional()
-    .describe(
-      "Human-readable label of the ontology term (e.g., 'gamma secretase activity')."
-    ),
   "dcterms:name": z
     .string()
-    .optional()
     .describe(
-      "Alternative property for human-readable name of the ontology term."
+      "Human-readable label of the ontology term (e.g., 'gamma secretase activity')."
     ),
   "dcterms:title": z
     .string()
@@ -168,7 +161,6 @@ export const OntologyTermSchema = z.object({
     ),
   "dcterms:description": z
     .string()
-    .optional()
     .describe(
       "Detailed description of the ontology term and its relevance to the paper."
     ),
@@ -244,7 +236,7 @@ const RelatedOrganizationSchema = z.object({
 });
 
 export const OntologiesSchema = z.object({
-  ontologies: z.array(OntologyTermSchema),
+  "schema:about": z.array(OntologyTermSchema),
 });
 
 // research paper schema
@@ -256,12 +248,12 @@ export const PaperSchema = z
       .describe(
         "Top-level identifier for the paper, typically a DOI (e.g., https://doi.org/10.1371/journal.pone.0173240)."
       )
+      // TODO: look into whether the default is screwing stuff up
       .default(`https://doi.org/10.1234/${crypto.randomInt(10000, 99999)}`),
-    "@type": z
-      .string()
-      .describe(
-        "Type of the paper (e.g., 'fabio:ResearchPaper', 'bibo:AcademicArticle', 'schema:ScholarlyArticle')."
-      ),
+    "@type": z.string().describe(
+      // TODO: perhaps should just use one of these
+      "Type of the paper (e.g., 'fabio:ResearchPaper', 'bibo:AcademicArticle', 'schema:ScholarlyArticle')."
+    ),
     "dcterms:title": z
       .string()
       .describe("Full title of the paper as it appears in the publication."),
@@ -334,11 +326,13 @@ export const PaperSchema = z
       .describe(
         "Plain text representation of the paper's content, useful for full-text search and analysis."
       ),
+    // TODO: this is not performing well
     "cito:cites": z
       .array(CitationSchema)
       .describe(
         "References/citations the paper includes, with identifiers and titles."
       ),
+    // TODO: these are never extracted it seems, but the OntologySchema is followed (ontologies:)
     "obi:OBI_0000299": z
       .array(OntologyTermSchema)
       .optional()

--- a/src/bioagentPlugin/services/gdrive/extract/z.ts
+++ b/src/bioagentPlugin/services/gdrive/extract/z.ts
@@ -153,11 +153,6 @@ export const OntologyTermSchema = z.object({
     .describe(
       "Human-readable label of the ontology term (e.g., 'gamma secretase activity')."
     ),
-  "schema:url": z
-    .string()
-    .describe(
-      "Full URL path to the ontology term (e.g., 'http://purl.obolibrary.org/obo/GO_0070765')."
-    ),
   "dcterms:description": z
     .string()
     .describe(

--- a/src/bioagentPlugin/services/kaService/v1/biologyApi.ts
+++ b/src/bioagentPlugin/services/kaService/v1/biologyApi.ts
@@ -9,16 +9,21 @@ import {
   get_doid_api_prompt,
   get_chebi_api_prompt,
   get_atc_api_prompt,
+  get_mondo_api_prompt,
+  get_eco_api_prompt,
+  get_pw_api_prompt,
+  get_mesh_api_prompt,
 } from "./llmPrompt";
 import Anthropic from "@anthropic-ai/sdk";
 
 const bioontologyApiKey: string | undefined = process.env.BIONTOLOGY_KEY;
 
 /**
- * Extract the last part of an ATC URL as the ATC ID.
+ * Extract the last part of a URL's path.
  * E.g., if the URL ends with "/A12BC51", returns "A12BC51".
+ * E.g., if URL is "http://purl.obolibrary.org/obo/PW_0000001", returns "PW_0000001".
  */
-export function extractAtcId(url: string): string | null {
+export function extractLastUriSegment(url: string): string | null {
   const match = url.match(/\/([^/]+)$/);
   return match ? match[1] : null;
 }
@@ -42,38 +47,45 @@ export async function searchGo(
       params,
     });
     if (apiResponse.status === 200) {
-      const goCandidates = apiResponse.data.results?.slice(0, 4) || [];
+      // QuickGO results are in apiResponse.data.results
+      // Each result has 'id', 'name', 'definition.text'
+      const goCandidates =
+        apiResponse.data.results?.slice(0, 4).map((candidate) => ({
+          short_form: candidate.id,
+          label: candidate.name,
+          description: candidate.definition?.text || "",
+        })) || [];
       const promptGoApi = get_go_api_prompt(term, goCandidates);
 
       newTerm = await generateResponse(client, promptGoApi, modelIdentifier);
 
-      // Replace "GO:" with "GO_"
       if (newTerm.includes("GO:")) {
         newTerm = newTerm.replace("GO:", "GO_");
       }
       logger.info(`new term: ${newTerm}, old term: ${term}`);
     } else {
-      logger.info(`EBI API gave response code ${apiResponse.status}`);
+      logger.info(`QuickGO API (GO) gave response code ${apiResponse.status}`);
     }
   } catch (error) {
-    logger.error(`Error generating response: ${error}`);
+    logger.error(`Error searching GO: ${error}`);
   }
 
   return newTerm;
 }
 
 /**
- * Search for a term in the DOID Ontology via EBI API.
+ * Search for a term in the DOID Ontology via EBI OLS4 API.
  */
 export async function searchDoid(
   term: string,
   client: Anthropic,
   modelIdentifier: string = "claude-3-haiku-20240307"
 ): Promise<string> {
-  const url = "https://www.ebi.ac.uk/ols/api/search";
+  const url = "https://www.ebi.ac.uk/ols4/api/search"; // Updated to OLS4
   const params = {
     q: term,
     ontology: "doid",
+    rows: 5, // OLS uses 'rows' for limit
   };
   const headers = { Accept: "application/json" };
 
@@ -87,11 +99,13 @@ export async function searchDoid(
     if (apiResponse.status === 200) {
       const data = apiResponse.data;
       const found = data.response?.numFound || 0;
+      // OLS4 results are in data.response.docs
+      // Each doc has 'short_form', 'label', 'description' (array)
       const doidCandidates =
         found > 0
           ? data.response.docs.slice(0, 4).map((candidate) => ({
               short_form: candidate.short_form,
-              description: candidate.description,
+              description: candidate.description?.[0] || "",
               label: candidate.label,
             }))
           : [];
@@ -99,33 +113,35 @@ export async function searchDoid(
       const promptDoidApi = get_doid_api_prompt(term, doidCandidates);
       newTerm = await generateResponse(client, promptDoidApi, modelIdentifier);
 
-      // Replace "DOID:" with "DOID_"
       if (newTerm.includes("DOID:")) {
         newTerm = newTerm.replace("DOID:", "DOID_");
       }
       logger.info(`new term: ${newTerm}, old term: ${term}`);
     } else {
-      logger.error(`EBI API gave response code ${apiResponse.status}`);
+      logger.error(
+        `EBI OLS4 API (DOID) gave response code ${apiResponse.status}`
+      );
     }
   } catch (error) {
-    logger.error(`Error generating response: ${error}`);
+    logger.error(`Error searching DOID: ${error}`);
   }
 
   return newTerm;
 }
 
 /**
- * Search for a term in the ChEBI Ontology via EBI API.
+ * Search for a term in the ChEBI Ontology via EBI OLS4 API.
  */
 export async function searchChebi(
   term: string,
   client: Anthropic,
   modelIdentifier: string = "claude-3-haiku-20240307"
 ): Promise<string> {
-  const url = "https://www.ebi.ac.uk/ols/api/search";
+  const url = "https://www.ebi.ac.uk/ols4/api/search"; // Updated to OLS4
   const params = {
     q: term,
     ontology: "chebi",
+    rows: 5, // OLS uses 'rows' for limit
   };
   const headers = { Accept: "application/json" };
 
@@ -139,11 +155,13 @@ export async function searchChebi(
     if (apiResponse.status === 200) {
       const data = apiResponse.data;
       const found = data.response?.numFound || 0;
+      // OLS4 results are in data.response.docs
+      // Each doc has 'short_form', 'label', 'description' (array)
       const chebiCandidates =
         found > 0
           ? data.response.docs.slice(0, 4).map((candidate) => ({
               short_form: candidate.short_form,
-              description: candidate.description,
+              description: candidate.description?.[0] || "",
               label: candidate.label,
             }))
           : [];
@@ -151,16 +169,17 @@ export async function searchChebi(
       const promptChebiApi = get_chebi_api_prompt(term, chebiCandidates);
       newTerm = await generateResponse(client, promptChebiApi, modelIdentifier);
 
-      // Replace "CHEBI:" with "CHEBI_"
       if (newTerm.includes("CHEBI:")) {
         newTerm = newTerm.replace("CHEBI:", "CHEBI_");
       }
       logger.info(`new term: ${newTerm}, old term: ${term}`);
     } else {
-      logger.error(`EBI API gave response code ${apiResponse.status}`);
+      logger.error(
+        `EBI OLS4 API (ChEBI) gave response code ${apiResponse.status}`
+      );
     }
   } catch (error) {
-    logger.error(`Error generating response: ${error}`);
+    logger.error(`Error searching ChEBI: ${error}`);
   }
 
   return newTerm;
@@ -179,6 +198,7 @@ export async function searchAtc(
     q: term,
     ontologies: "ATC",
     apikey: bioontologyApiKey,
+    pagesize: 5, // BioOntology uses 'pagesize'
   };
   const headers = { Accept: "application/json" };
 
@@ -191,11 +211,13 @@ export async function searchAtc(
 
     if (apiResponse.status === 200) {
       const data = apiResponse.data;
+      // BioOntology results are in data.collection
+      // Each result has '@id', 'prefLabel', 'definition' (array)
       let atcCandidates = [];
       if (data.collection && data.collection.length > 0) {
-        atcCandidates = data.collection.map((candidate) => ({
-          short_form: extractAtcId(candidate["@id"]),
-          description: "",
+        atcCandidates = data.collection.slice(0, 4).map((candidate) => ({
+          short_form: extractLastUriSegment(candidate["@id"]),
+          description: candidate["definition"]?.[0] || "",
           label: candidate["prefLabel"],
         }));
       }
@@ -204,64 +226,270 @@ export async function searchAtc(
 
       logger.info(`new term: ${newTerm}, old term: ${term}`);
     } else {
-      logger.error(`ATC API gave response code ${apiResponse.status}`);
+      logger.error(
+        `BioOntology API (ATC) gave response code ${apiResponse.status}`
+      );
     }
   } catch (error) {
-    logger.error(`Error generating response: ${error}`);
+    logger.error(`Error searching ATC: ${error}`);
   }
 
   return newTerm;
 }
 
 /**
- * Update subject and object fields in GO data with best-matching GO terms.
+ * Search for a term in the Mondo Ontology via EBI OLS4 API.
  */
-export async function updateGoTerms(data, client: Anthropic) {
-  for (const entry of data) {
-    const subjectResult = await searchGo(entry.subject, client);
-    entry.subject = { term: entry.subject, id: subjectResult };
+export async function searchMondo(
+  term: string,
+  client: Anthropic,
+  modelIdentifier: string = "claude-3-haiku-20240307"
+): Promise<string> {
+  const url = "https://www.ebi.ac.uk/ols4/api/search";
+  const params = {
+    q: term,
+    ontology: "mondo",
+    rows: 5,
+  };
+  const headers = { Accept: "application/json" };
 
-    const objectResult = await searchGo(entry.object, client);
-    entry.object = { term: entry.object, id: objectResult };
+  let newTerm = "None";
+  try {
+    const apiResponse: AxiosResponse = await axios.get(url, {
+      headers,
+      params,
+    });
+
+    if (apiResponse.status === 200) {
+      const data = apiResponse.data;
+      const found = data.response?.numFound || 0;
+      const mondoCandidates =
+        found > 0
+          ? data.response.docs.slice(0, 4).map((candidate) => ({
+              short_form: candidate.short_form,
+              description: candidate.description?.[0] || "",
+              label: candidate.label,
+            }))
+          : [];
+
+      const promptMondoApi = get_mondo_api_prompt(term, mondoCandidates);
+      newTerm = await generateResponse(client, promptMondoApi, modelIdentifier);
+
+      if (newTerm.includes("MONDO:")) {
+        newTerm = newTerm.replace("MONDO:", "MONDO_");
+      }
+      logger.info(`new term: ${newTerm}, old term: ${term}`);
+    } else {
+      logger.error(
+        `EBI OLS4 API (Mondo) gave response code ${apiResponse.status}`
+      );
+    }
+  } catch (error) {
+    logger.error(`Error searching Mondo: ${error}`);
+  }
+  return newTerm;
+}
+
+/**
+ * Search for a term in the ECO Ontology via QuickGO API.
+ */
+export async function searchEco(
+  term: string,
+  client: Anthropic,
+  modelIdentifier: string = "claude-3-haiku-20240307"
+): Promise<string> {
+  const url = "https://www.ebi.ac.uk/QuickGO/services/ontology/eco/search";
+  const params = { query: term, limit: 5, page: 1 };
+  const headers = { Accept: "application/json" };
+
+  let newTerm = "None";
+  try {
+    const apiResponse: AxiosResponse = await axios.get(url, {
+      headers,
+      params,
+    });
+    if (apiResponse.status === 200) {
+      const ecoCandidates =
+        apiResponse.data.results?.slice(0, 4).map((candidate) => ({
+          short_form: candidate.id, // QuickGO uses 'id'
+          label: candidate.name, // QuickGO uses 'name'
+          description: candidate.definition?.text || "",
+        })) || [];
+      const promptEcoApi = get_eco_api_prompt(term, ecoCandidates);
+
+      newTerm = await generateResponse(client, promptEcoApi, modelIdentifier);
+
+      if (newTerm.includes("ECO:")) {
+        newTerm = newTerm.replace("ECO:", "ECO_");
+      }
+      logger.info(`new term: ${newTerm}, old term: ${term}`);
+    } else {
+      logger.info(`QuickGO API (ECO) gave response code ${apiResponse.status}`);
+    }
+  } catch (error) {
+    logger.error(`Error searching ECO: ${error}`);
   }
 
+  return newTerm;
+}
+
+/**
+ * Search for a term in the Pathway Ontology (PW) via BioOntology API.
+ */
+export async function searchPw(
+  term: string,
+  client: Anthropic,
+  modelIdentifier: string = "claude-3-haiku-20240307"
+): Promise<string> {
+  const url = "https://data.bioontology.org/search";
+  const params = {
+    q: term,
+    ontologies: "PW",
+    apikey: bioontologyApiKey,
+    pagesize: 5,
+  };
+  const headers = { Accept: "application/json" };
+
+  let newTerm = "None";
+  try {
+    const apiResponse: AxiosResponse = await axios.get(url, {
+      headers,
+      params,
+    });
+
+    if (apiResponse.status === 200) {
+      const data = apiResponse.data;
+      let pwCandidates = [];
+      if (data.collection && data.collection.length > 0) {
+        pwCandidates = data.collection.slice(0, 4).map((candidate) => ({
+          short_form: extractLastUriSegment(candidate["@id"]),
+          description: candidate["definition"]?.[0] || "",
+          label: candidate["prefLabel"],
+        }));
+      }
+      const promptPwApi = get_pw_api_prompt(term, pwCandidates);
+      newTerm = await generateResponse(client, promptPwApi, modelIdentifier);
+      logger.info(`new term: ${newTerm}, old term: ${term}`);
+    } else {
+      logger.error(
+        `BioOntology API (PW) gave response code ${apiResponse.status}`
+      );
+    }
+  } catch (error) {
+    logger.error(`Error searching Pathway Ontology (PW): ${error}`);
+  }
+  return newTerm;
+}
+
+/**
+ * Search for a term in the MeSH Ontology via BioOntology API.
+ */
+export async function searchMesh(
+  term: string,
+  client: Anthropic,
+  modelIdentifier: string = "claude-3-haiku-20240307"
+): Promise<string> {
+  const url = "https://data.bioontology.org/search";
+  const params = {
+    q: term,
+    ontologies: "MESH",
+    apikey: bioontologyApiKey,
+    pagesize: 5,
+  };
+  const headers = { Accept: "application/json" };
+
+  let newTerm = "None";
+  try {
+    const apiResponse: AxiosResponse = await axios.get(url, {
+      headers,
+      params,
+    });
+
+    if (apiResponse.status === 200) {
+      const data = apiResponse.data;
+      let meshCandidates = [];
+      if (data.collection && data.collection.length > 0) {
+        meshCandidates = data.collection.slice(0, 4).map((candidate) => ({
+          short_form: extractLastUriSegment(candidate["@id"]),
+          description: candidate["definition"]?.[0] || "",
+          label: candidate["prefLabel"],
+        }));
+      }
+      const promptMeshApi = get_mesh_api_prompt(term, meshCandidates);
+      newTerm = await generateResponse(client, promptMeshApi, modelIdentifier);
+      logger.info(`new term: ${newTerm}, old term: ${term}`);
+    } else {
+      logger.error(
+        `BioOntology API (MeSH) gave response code ${apiResponse.status}`
+      );
+    }
+  } catch (error) {
+    logger.error(`Error searching MeSH: ${error}`);
+  }
+  return newTerm;
+}
+
+// --- Existing Update Functions ---
+// (Keeping these as they were, as per your request to only add new search functions)
+
+/**
+ * Update subject and object fields in GO data with best-matching GO terms.
+ */
+export async function updateGoTerms(data: any[], client: Anthropic) {
+  for (const entry of data) {
+    if (entry.subject) {
+      const subjectResult = await searchGo(entry.subject, client);
+      entry.subject = { term: entry.subject, id: subjectResult };
+    }
+    if (entry.object) {
+      const objectResult = await searchGo(entry.object, client);
+      entry.object = { term: entry.object, id: objectResult };
+    }
+  }
   return data.filter(
-    (entry) => entry.subject !== "None" && entry.object !== "None"
+    (entry) =>
+      (entry.subject?.id !== "None" || !entry.subject) &&
+      (entry.object?.id !== "None" || !entry.object)
   );
 }
 
 /**
  * Update disease fields in DOID data with best-matching DOID terms.
  */
-export async function updateDoidTerms(data, client: Anthropic) {
+export async function updateDoidTerms(data: any[], client: Anthropic) {
   for (const entry of data) {
-    const diseaseResult = await searchDoid(entry.disease, client);
-    entry.disease_id = diseaseResult;
+    if (entry.disease) {
+      const diseaseResult = await searchDoid(entry.disease, client);
+      entry.disease_id = diseaseResult;
+    }
   }
-
-  return data.filter((entry) => entry.disease_id !== "None");
+  return data.filter((entry) => entry.disease_id !== "None" || !entry.disease);
 }
 
 /**
  * Update compound fields in ChEBI data with best-matching ChEBI terms.
  */
-export async function updateChebiTerms(data, client: Anthropic) {
+export async function updateChebiTerms(data: any[], client: Anthropic) {
   for (const entry of data) {
-    const compoundResult = await searchChebi(entry.compound, client);
-    entry.compound_id = compoundResult;
+    if (entry.compound) {
+      const compoundResult = await searchChebi(entry.compound, client);
+      entry.compound_id = compoundResult;
+    }
   }
-
-  return data.filter((entry) => entry.compound_id !== "None");
+  return data.filter(
+    (entry) => entry.compound_id !== "None" || !entry.compound
+  );
 }
 
 /**
  * Update drug fields in ATC data with best-matching ATC terms.
  */
-export async function updateAtcTerms(data, client: Anthropic) {
+export async function updateAtcTerms(data: any[], client: Anthropic) {
   for (const entry of data) {
-    const drugResult = await searchAtc(entry.drug, client);
-    entry.drug_id = drugResult;
+    if (entry.drug) {
+      const drugResult = await searchAtc(entry.drug, client);
+      entry.drug_id = drugResult;
+    }
   }
-
-  return data.filter((entry) => entry.drug_id !== "None");
+  return data.filter((entry) => entry.drug_id !== "None" || !entry.drug);
 }

--- a/src/bioagentPlugin/services/kaService/v1/llmPrompt.ts
+++ b/src/bioagentPlugin/services/kaService/v1/llmPrompt.ts
@@ -1,30 +1,30 @@
 // prompts.ts
 
 import {
-    basic_info_example_input,
-    basic_info_example_output,
-    citations_example_input,
-    citations_example_output,
-    subgraph_go_example_input,
-    subgraph_go_example_output,
-    subgraph_doid_example_input,
-    subgraph_doid_example_output,
-    subgraph_chebi_example_input,
-    subgraph_chebi_example_output,
-    subgraph_atc_example_input,
-    subgraph_atc_example_output,
-    example_basic_info,
-    example_spar_output,
-    example_go_output,
-    example_doid_output,
-    example_chebi_output,
-    gene_ontology_example_input,
-    doid_ontology_example_input,
-    chebi_ontology_example_input,
-    example_json_citations,
-    example_graph,
-    incorrect_json_example,
-    correct_json_example,
+  basic_info_example_input,
+  basic_info_example_output,
+  citations_example_input,
+  citations_example_output,
+  subgraph_go_example_input,
+  subgraph_go_example_output,
+  subgraph_doid_example_input,
+  subgraph_doid_example_output,
+  subgraph_chebi_example_input,
+  subgraph_chebi_example_output,
+  subgraph_atc_example_input,
+  subgraph_atc_example_output,
+  example_basic_info,
+  example_spar_output,
+  example_go_output,
+  example_doid_output,
+  example_chebi_output,
+  gene_ontology_example_input,
+  doid_ontology_example_input,
+  chebi_ontology_example_input,
+  example_json_citations,
+  example_graph,
+  incorrect_json_example,
+  correct_json_example,
 } from "./exampleForPrompts";
 
 /**
@@ -32,7 +32,7 @@ import {
  * from a list of GO candidates.
  */
 export function get_go_api_prompt(term: string, go_candidates): string {
-    return `
+  return `
     Given the biological context, which of the following Gene Ontology (GO) terms best matches the description for '${term}'? Please select the most appropriate GO term or indicate if none apply by replying 'None'.
 
     GO Candidates in JSON format: ${JSON.stringify(go_candidates)}
@@ -47,7 +47,7 @@ export function get_go_api_prompt(term: string, go_candidates): string {
  * from a list of DOID candidates.
  */
 export function get_doid_api_prompt(term: string, doid_candidates): string {
-    return `
+  return `
     Given the biological context, which of the following Disease Ontology (DOID) terms best matches the description for '${term}'? Please select the most appropriate DOID term or indicate if none apply by replying 'None'.
 
     DOID Candidates in JSON format: ${JSON.stringify(doid_candidates)}
@@ -62,7 +62,7 @@ export function get_doid_api_prompt(term: string, doid_candidates): string {
  * from a list of ChEBI candidates.
  */
 export function get_chebi_api_prompt(term: string, chebi_candidates): string {
-    return `
+  return `
     Given the biological context, which of the following Chemical Entities of Biological Interest (ChEBI) terms best matches the description for '${term}'? Please select the most appropriate ChEBI term or indicate if none apply by replying 'None'.
 
     ChEBI Candidates in JSON format: ${JSON.stringify(chebi_candidates)}
@@ -77,7 +77,7 @@ export function get_chebi_api_prompt(term: string, chebi_candidates): string {
  * from a list of ATC candidates.
  */
 export function get_atc_api_prompt(term: string, atc_candidates): string {
-    return `
+  return `
     Given the biological context, which of the following Anatomical Therapeutic Chemical (ATC) terms best matches the description for '${term}'? Please select the most appropriate ATC term or indicate if none apply by replying 'None'.
 
     ATC Candidates in JSON format: ${JSON.stringify(atc_candidates)}
@@ -88,11 +88,71 @@ export function get_atc_api_prompt(term: string, atc_candidates): string {
 }
 
 /**
+ * Returns a prompt for choosing the most appropriate Mondo term
+ * from a list of Mondo candidates.
+ */
+export function get_mondo_api_prompt(term: string, mondo_candidates): string {
+  return `
+      Given the biological context, which of the following Mondo Disease Ontology terms best matches the description for '${term}'? Please select the most appropriate Mondo term or indicate if none apply by replying 'None'.
+  
+      Mondo Candidates in JSON format: ${JSON.stringify(mondo_candidates)}
+  
+      You must output the Mondo candidate which is the most suitable by replying with its id (e.g. 'MONDO_0005015'). If there are no suitable candidates output 'None'.
+      MAKE SURE TO ONLY OUTPUT THE MOST SUITABLE ID OR 'None'. THE ID MUST BE IN FORMAT "MONDO_NUMBER" - USE "_" ALWAYS. DO NOT OUTPUT ANYTHING ELSE.
+      `;
+}
+
+/**
+ * Returns a prompt for choosing the most appropriate ECO term
+ * from a list of ECO candidates.
+ */
+export function get_eco_api_prompt(term: string, eco_candidates): string {
+  return `
+      Given the biological context, which of the following Evidence & Conclusion Ontology (ECO) terms best matches the description for '${term}'? Please select the most appropriate ECO term or indicate if none apply by replying 'None'.
+  
+      ECO Candidates in JSON format: ${JSON.stringify(eco_candidates)}
+  
+      You must output the ECO candidate which is the most suitable by replying with its id (e.g. 'ECO_0000006'). If there are no suitable candidates output 'None'.
+      MAKE SURE TO ONLY OUTPUT THE MOST SUITABLE ID OR 'None'. THE ID MUST BE IN FORMAT "ECO_NUMBER" - USE "_" ALWAYS. DO NOT OUTPUT ANYTHING ELSE.
+      `;
+}
+
+/**
+ * Returns a prompt for choosing the most appropriate Pathway Ontology (PW) term
+ * from a list of PW candidates.
+ */
+export function get_pw_api_prompt(term: string, pw_candidates): string {
+  return `
+      Given the biological context, which of the following Pathway Ontology (PW) terms best matches the description for '${term}'? Please select the most appropriate PW term or indicate if none apply by replying 'None'.
+  
+      PW Candidates in JSON format: ${JSON.stringify(pw_candidates)}
+  
+      You must output the PW candidate which is the most suitable by replying with its id (e.g. 'PW_0001059'). If there are no suitable candidates, output 'None'.
+      MAKE SURE TO ONLY OUTPUT THE MOST SUITABLE ID OR 'None'.
+      `;
+}
+
+/**
+ * Returns a prompt for choosing the most appropriate MeSH term
+ * from a list of MeSH candidates.
+ */
+export function get_mesh_api_prompt(term: string, mesh_candidates): string {
+  return `
+      Given the biological context, which of the following Medical Subject Headings (MeSH) terms best matches the description for '${term}'? Please select the most appropriate MeSH term or indicate if none apply by replying 'None'.
+  
+      MeSH Candidates in JSON format: ${JSON.stringify(mesh_candidates)}
+  
+      You must output the MeSH candidate which is the most suitable by replying with its id (e.g. 'D008881'). If there are no suitable candidates, output 'None'.
+      MAKE SURE TO ONLY OUTPUT THE MOST SUITABLE ID OR 'None'.
+      `;
+}
+
+/**
  * Returns a prompt for extracting basic paper info (title, authors, abstract, etc.)
  * from an array of paper JSON chunks.
  */
 export function get_prompt_basic_info(paper_array): string {
-    return `**Prompt**:
+  return `**Prompt**:
     You are provided with chunks of a scientific paper in the form of JSON array elements, each containing parts of the paper such as potential titles, authors, and abstracts. Your task is to analyze these chunks incrementally to update and output the information listed below. If an element contains relevant information that improves upon or adds to the current data, update the respective fields; otherwise.
 
     **Task**
@@ -132,7 +192,7 @@ export function get_prompt_basic_info(paper_array): string {
  * Returns a prompt for extracting citation info from the last pages of a paper.
  */
 export function get_prompt_citations(paper_array): string {
-    return `**Prompt**:
+  return `**Prompt**:
     Analyze the provided chunks of the final few pages of a scientific paper formatted as JSON array elements. Each element contains potential citations, likely preceded by the term 'References'.
 
     **Task**:
@@ -164,7 +224,7 @@ export function get_prompt_citations(paper_array): string {
  * Returns a prompt for extracting Gene Ontology (GO) relationships from a parsed paper.
  */
 export function get_prompt_go_subgraph(paper_array): string {
-    return `**Prompt**:
+  return `**Prompt**:
     You are provided with a parsed scientific paper in the form of a JSON array. Analyze this array to extract relationships using Gene Ontology (GO) terms and identifiers based on the scientific analysis conducted within the paper. Utilize only the recognized relationships in the Gene Ontology, which include: "is_a", "part_of", "regulates", "positively_regulates", "negatively_regulates", "occurs_in", "capable_of", "capable_of_part_of", "has_part", "has_input", "has_output", "derives_from", and "derives_into". Each extracted relationship should be accompanied by a brief explanation that clarifies the relationship within the context of the scientific findings.
 
     Structure your response as a JSON array containing objects. Each object should have the following properties:
@@ -194,7 +254,7 @@ export function get_prompt_go_subgraph(paper_array): string {
  * using DOID (Disease Ontology).
  */
 export function get_prompt_doid_subgraph(paper_array): string {
-    return `**Prompt**:
+  return `**Prompt**:
     You are provided with a parsed scientific paper in the form of a JSON array. Analyze this array to extract diseases and findings about them using Human Disease Ontology (DOID) terms and identifiers based on the scientific analysis conducted within the paper.
 
     Structure your response as a JSON array containing objects. Each object should have the following properties:
@@ -223,7 +283,7 @@ export function get_prompt_doid_subgraph(paper_array): string {
  * using ChEBI (Chemical Entities of Biological Interest).
  */
 export function get_prompt_chebi_subgraph(paper_array): string {
-    return `**Prompt**:
+  return `**Prompt**:
     You are provided with a parsed scientific paper in the form of a JSON array. Analyze this array to extract chemical compounds and findings about them using Chemical Entities of Biological Interest (ChEBI) terms and identifiers based on the scientific analysis conducted within the paper.
 
     Structure your response as a JSON array containing objects. Each object should have the following properties:
@@ -252,7 +312,7 @@ export function get_prompt_chebi_subgraph(paper_array): string {
  * using the ATC (Anatomical Therapeutic Chemical) classification.
  */
 export function get_prompt_atc_subgraph(paper_array): string {
-    return `**Prompt**:
+  return `**Prompt**:
     You are provided with a parsed scientific paper in the form of a JSON array. Analyze this array to extract medications and findings about them using Anatomical Therapeutic Chemical (ATC) terms and identifiers based on the scientific analysis conducted within the paper.
 
     Structure your response as a JSON array containing objects. Each object should have the following properties:
@@ -280,7 +340,7 @@ export function get_prompt_atc_subgraph(paper_array): string {
  * Returns a prompt to transform citation info into SPAR-compliant JSON-LD.
  */
 export function get_prompt_spar_citations(citations: string): string {
-    return `
+  return `
     **Task**
     Transform the provided citation information about a scientific paper into a JSON array of citations following the format I provide you.
     One citation should be represented as one object, with an "@id" field which represents the DOI URL and "dcterms:title" field which represents the title, and only the title, author name can be removed in the "dcterms:title" field.
@@ -301,7 +361,7 @@ export function get_prompt_spar_citations(citations: string): string {
  * Returns a prompt to transform basic paper info into a SPAR/OBI-based JSON-LD.
  */
 export function get_prompt_spar_ontology(basic_info_text: string): string {
-    return `
+  return `
     ** Task: **
     Transform the provided basic information about a scientific paper into a JSON-LD object using appropriate elements from the SPAR Ontologies. The input includes key metadata such as title, authors, abstract, and other publication details. Your task is to utilize the FaBiO, CiTO, DoCO, and PRO ontologies to create a rich, semantically detailed representation of the paper.
 
@@ -353,7 +413,7 @@ export function get_prompt_spar_ontology(basic_info_text: string): string {
  * Returns a prompt to transform a GO subgraph into a JSON array using GO relationships.
  */
 export function get_prompt_go_ontology(generated_go_subgraph): string {
-    return `
+  return `
     ** Task: **
     Transform the provided basic information about a scientific paper into a JSON array using appropriate elements from the Gene Ontology (GO). The input includes Gene Ontology (GO) terms in a simple JSON format which you should transfer into an array format for an RDF graph. Your task is to utilize the GO ontology to create a rich, semantically detailed representation of terms and relationships described.
 
@@ -394,9 +454,9 @@ export function get_prompt_go_ontology(generated_go_subgraph): string {
 
     ** Actual Input JSON **
     Gene Ontology terms and relationships: ${JSON.stringify(
-        generated_go_subgraph,
-        null,
-        2
+      generated_go_subgraph,
+      null,
+      2
     )}
 
     ** Note **
@@ -410,7 +470,7 @@ export function get_prompt_go_ontology(generated_go_subgraph): string {
  * Returns a prompt to transform a DOID subgraph into a JSON array using DOID relationships.
  */
 export function get_prompt_doid_ontology(generated_doid_subgraph): string {
-    return `
+  return `
     ** Task: **
     Transform the provided basic information about a scientific paper into a JSON array using appropriate elements from the Disease Ontology (DOID). The input includes Disease Ontology (DOID) terms in a simple JSON format which you should transfer into an array format for an RDF graph. Your task is to utilize the DOID ontology to create a rich, semantically detailed representation of terms and relationships described.
 
@@ -440,9 +500,9 @@ export function get_prompt_doid_ontology(generated_doid_subgraph): string {
 
     ** Actual Input JSON **
     Disease ontology terms and relationships: ${JSON.stringify(
-        generated_doid_subgraph,
-        null,
-        2
+      generated_doid_subgraph,
+      null,
+      2
     )}
 
     ** Note **
@@ -456,7 +516,7 @@ export function get_prompt_doid_ontology(generated_doid_subgraph): string {
  * Returns a prompt to transform a ChEBI subgraph into a JSON array using ChEBI relationships.
  */
 export function get_prompt_chebi_ontology(generated_chebi_subgraph): string {
-    return `
+  return `
     ** Task: **
     Transform the provided basic information about a scientific paper into a JSON array using appropriate elements from the Chemical Entities of Biological Interest (ChEBI). The input includes ChEBI terms in a simple JSON format which you should transfer into an array format for an RDF graph. Your task is to utilize the ChEBI ontology to create a rich, semantically detailed representation of terms and relationships described.
 
@@ -486,9 +546,9 @@ export function get_prompt_chebi_ontology(generated_chebi_subgraph): string {
 
     ** Actual Input JSON **
     Disease ontology terms and relationships: ${JSON.stringify(
-        generated_chebi_subgraph,
-        null,
-        2
+      generated_chebi_subgraph,
+      null,
+      2
     )}
 
     ** Note **
@@ -503,18 +563,18 @@ export function get_prompt_chebi_ontology(generated_chebi_subgraph): string {
  * given an array of page text data.
  */
 export function get_prompt_section_page_numbers(
-    paper_array,
-    sections: string[]
+  paper_array,
+  sections: string[]
 ): string {
-    let prompt = `Given the following pages of a research paper, identify the start and stop pages for each one of the provided sections\n\n`;
+  let prompt = `Given the following pages of a research paper, identify the start and stop pages for each one of the provided sections\n\n`;
 
-    paper_array.forEach((element) => {
-        const pageNumber = element.metadata?.page_number;
-        const text = element.text;
-        prompt += `Page ${pageNumber}:\n${text}\n\n`;
-    });
+  paper_array.forEach((element) => {
+    const pageNumber = element.metadata?.page_number;
+    const text = element.text;
+    prompt += `Page ${pageNumber}:\n${text}\n\n`;
+  });
 
-    prompt += `Please provide the start and stop pages for each section in the following format:
+  prompt += `Please provide the start and stop pages for each section in the following format:
     
     ** Example input (ONLY AN EXAMPLE, DO NOT COPY DATA FROM HERE FOR ACTUAL OUTPUT)**
     Introduction, abstract
@@ -528,14 +588,14 @@ export function get_prompt_section_page_numbers(
 
     ** Your output **
     ${JSON.stringify(
-        sections.map((section) => `${section}, start, end`),
-        null,
-        2
+      sections.map((section) => `${section}, start, end`),
+      null,
+      2
     )}
 
     OUTPUT ONLY THE SECTIONS AND PAGE NUMBERS IN THE EXAMPLE FORMAT, ONLY FOR THE SECTIONS FROM THE INPUT. DO NOT CONSIDER OTHER SECTIONS OR ADD ANY OTHER COMMENTS, EXPLANATIONS ETC. 
     `;
-    return prompt;
+  return prompt;
 }
 
 /**
@@ -543,13 +603,13 @@ export function get_prompt_section_page_numbers(
  * from an RDF JSON-LD graph.
  */
 export function get_prompt_vectorization_summary(graph): string {
-    // Shallow clone of the graph
-    const graphCopy = JSON.parse(JSON.stringify(graph));
-    if (graphCopy["cito:cites"]) {
-        delete graphCopy["cito:cites"];
-    }
+  // Shallow clone of the graph
+  const graphCopy = JSON.parse(JSON.stringify(graph));
+  if (graphCopy["cito:cites"]) {
+    delete graphCopy["cito:cites"];
+  }
 
-    return `
+  return `
     ** Task: **
     Generate a comprehensive textual summary based on the provided RDF JSON-LD graph. The summary should include as much information as possible that would be useful for similarity search.
 
@@ -596,7 +656,7 @@ export function get_prompt_vectorization_summary(graph): string {
  * Returns a prompt to convert incorrectly formatted text into valid JSON.
  */
 export function get_prompt_convert_to_json(incorrect_json: string): string {
-    return `
+  return `
     ** Task: **
     Convert the following incorrectly formatted text into a valid JSON format. Ensure that any incomplete or cut-off elements are properly removed, and the resulting JSON structure is correct.
 
@@ -633,12 +693,12 @@ export function get_prompt_convert_to_json(incorrect_json: string): string {
  * based on the given RDF JSON-LD graph.
  */
 export function get_prompt_suggested_questions(graph): string {
-    const graphCopy = JSON.parse(JSON.stringify(graph));
-    if (graphCopy["cito:cites"]) {
-        delete graphCopy["cito:cites"];
-    }
+  const graphCopy = JSON.parse(JSON.stringify(graph));
+  if (graphCopy["cito:cites"]) {
+    delete graphCopy["cito:cites"];
+  }
 
-    return `
+  return `
     ** Task: **
     Generate three suggested research questions based on the provided RDF JSON-LD graph. The questions should be related to the key entities, assets, or topics in the graph and should be useful for exploring the content further.
 

--- a/src/bioagentPlugin/services/kaService/v2/grobidClient.ts
+++ b/src/bioagentPlugin/services/kaService/v2/grobidClient.ts
@@ -11,8 +11,8 @@ export async function processFulltextDocument(file: Buffer) {
   const form = new FormData();
 
   form.append("consolidateHeader", "1");
-  form.append("consolidateCitations", "1");
-  form.append("consolidateFunders", "1");
+  // form.append("consolidateCitations", "1");
+  // form.append("consolidateFunders", "1");
   form.append("includeRawAffiliations", "1");
   form.append("includeRawCitations", "1");
   form.append("segmentSentences", "1");
@@ -31,7 +31,7 @@ export async function processFulltextDocument(file: Buffer) {
     // GROBID can spit out TEI up to several MB; disable the limits
     maxBodyLength: Infinity,
     maxContentLength: Infinity,
-    timeout: 300_000, // ms – tune to your latency
+    timeout: 120_000, // ms – tune to your latency
   });
 
   const end = new Date();

--- a/src/bioagentPlugin/services/kaService/v2/grobidClient.ts
+++ b/src/bioagentPlugin/services/kaService/v2/grobidClient.ts
@@ -31,7 +31,7 @@ export async function processFulltextDocument(file: Buffer) {
     // GROBID can spit out TEI up to several MB; disable the limits
     maxBodyLength: Infinity,
     maxContentLength: Infinity,
-    timeout: 120_000, // ms – tune to your latency
+    timeout: 300_000, // ms – tune to your latency
   });
 
   const end = new Date();

--- a/src/bioagentPlugin/services/kaService/v2/parseTeiXml.ts
+++ b/src/bioagentPlugin/services/kaService/v2/parseTeiXml.ts
@@ -2,25 +2,56 @@ import libxmljs from "libxmljs";
 
 const ns = { tei: "http://www.tei-c.org/ns/1.0" };
 
+// Section definitions with main name and synonyms
+const SECTION_DEFINITIONS = {
+  introduction: ["introduction", "intro", "background"],
+  methods: ["methods", "method", "methodology", "materials and methods"],
+  results: ["results", "result", "findings"],
+  discussion: ["discussion", "analysis", "interpretation"],
+  conclusion: ["conclusion", "remarks", "summary"],
+  futureWork: ["future work", "future research", "next steps"],
+  appendix: ["appendix", "material", "supplementary"],
+};
+
+/**
+ * Enhanced function to find and extract section content with multiple synonyms
+ */
 function findAndExtractSectionContent(
   // @ts-ignore
   doc: libxmljs.Document,
-  sectionNameLC: string,
+  sectionSynonyms: string[],
   namespaces: object
 ) {
   let sectionDiv = null;
 
-  // XPath to find by type attribute (preferred if available)
-  const xpathType = `//tei:body//tei:div[@type='${sectionNameLC}']`;
-  sectionDiv = doc.get(xpathType, namespaces);
+  // Try each synonym until we find a match
+  for (const synonym of sectionSynonyms) {
+    // XPath to find by type attribute - EXACT match (preferred if available)
+    const xpathTypeExact = `//tei:body//tei:div[@type='${synonym}']`;
+    sectionDiv = doc.get(xpathTypeExact, namespaces);
 
-  // If not found by type, try finding by <head> content (case-insensitive)
-  if (!sectionDiv) {
-    const xpathHead = `//tei:body//tei:div[translate(tei:head, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = '${sectionNameLC}']`;
-    sectionDiv = doc.get(xpathHead, namespaces);
+    if (sectionDiv) break;
+
+    // XPath to find by type attribute - PARTIAL match (contains)
+    const xpathTypeContains = `//tei:body//tei:div[contains(translate(@type, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '${synonym}')]`;
+    sectionDiv = doc.get(xpathTypeContains, namespaces);
+
+    if (sectionDiv) break;
+
+    // If not found by type, try finding by <head> content - EXACT match (case-insensitive)
+    const xpathHeadExact = `//tei:body//tei:div[translate(tei:head, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = '${synonym}']`;
+    sectionDiv = doc.get(xpathHeadExact, namespaces);
+
+    if (sectionDiv) break;
+
+    // Also try partial matching for head content
+    const xpathHeadContains = `//tei:body//tei:div[contains(translate(tei:head, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '${synonym}')]`;
+    sectionDiv = doc.get(xpathHeadContains, namespaces);
+
+    if (sectionDiv) break;
   }
 
-  // If a div was found by either method, extract its content excluding the head
+  // If a div was found by any method, extract its content excluding the head
   if (sectionDiv) {
     // Find all direct child elements (*) of the sectionDiv that are NOT the <head> element
     const contentNodes = sectionDiv.find(
@@ -38,7 +69,7 @@ function findAndExtractSectionContent(
     }
   }
 
-  // If no div was found by either method
+  // If no div was found by any method
   return null;
 }
 
@@ -64,6 +95,21 @@ export async function parseXml(teiXml: string) {
   try {
     const doc = libxmljs.parseXml(teiXml);
 
+    // 0. Extract Title
+    const title =
+      extractTextSimple(
+        doc,
+        "/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title[@level='a'][@type='main']",
+        ns
+      ) ||
+      extractTextSimple(
+        doc,
+        "/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title",
+        ns
+      );
+
+    console.log(`[parseXml] Got title: ${title}`);
+
     // 1. Extract DOI (using simple helper)
     const doi =
       extractTextSimple(
@@ -88,33 +134,145 @@ export async function parseXml(teiXml: string) {
     // 3. Extract Citations (using simple helper - common location)
     const citations = extractTextSimple(doc, "//tei:back//tei:listBibl", ns);
 
-    // 4. Extract Body Sections (using the robust helper)
-    const introduction = findAndExtractSectionContent(doc, "introduction", ns);
-    const methods = findAndExtractSectionContent(doc, "methods", ns);
-    const results = findAndExtractSectionContent(doc, "results", ns); // This will handle your example
-    const discussion = findAndExtractSectionContent(doc, "discussion", ns);
+    console.log(`[parseXml] Got citations of length: ${citations?.length}`);
+
+    // 4. Extract Body Sections with synonyms
+    const introduction = findAndExtractSectionContent(
+      doc,
+      SECTION_DEFINITIONS.introduction,
+      ns
+    );
+
+    console.log(`[parseXml] Got introduction: ${introduction?.length || 0}`);
+
+    const methods = findAndExtractSectionContent(
+      doc,
+      SECTION_DEFINITIONS.methods,
+      ns
+    );
+
+    console.log(`[parseXml] Got methods: ${methods?.length || 0}`);
+
+    const results = findAndExtractSectionContent(
+      doc,
+      SECTION_DEFINITIONS.results,
+      ns
+    );
+
+    console.log(`[parseXml] Got results: ${results?.length || 0}`);
+
+    const discussion = findAndExtractSectionContent(
+      doc,
+      SECTION_DEFINITIONS.discussion,
+      ns
+    );
+
+    console.log(`[parseXml] Got discussion: ${discussion?.length || 0}`);
+
+    const conclusion = findAndExtractSectionContent(
+      doc,
+      SECTION_DEFINITIONS.conclusion,
+      ns
+    );
+
+    console.log(`[parseXml] Got conclusion: ${conclusion?.length || 0}`);
+
+    const futureWork = findAndExtractSectionContent(
+      doc,
+      SECTION_DEFINITIONS.futureWork,
+      ns
+    );
+
+    console.log(`[parseXml] Got future work: ${futureWork?.length || 0}`);
+
+    const appendix = findAndExtractSectionContent(
+      doc,
+      SECTION_DEFINITIONS.appendix,
+      ns
+    );
+
+    console.log(`[parseXml] Got appendix: ${appendix?.length || 0}`);
+
+    // 5. Extract Publication Date
+    const datePublished = extractTextSimple(
+      doc,
+      "/tei:TEI/tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:date[@type='published']",
+      ns
+    );
+
+    console.log(`[parseXml] Got publication date: ${datePublished}`);
+
+    // 6. Extract Publisher
+    const publisher = extractTextSimple(
+      doc,
+      "/tei:TEI/tei:teiHeader/tei:fileDesc/tei:publicationStmt/tei:publisher",
+      ns
+    );
+
+    console.log(`[parseXml] Got publisher: ${publisher}`);
+
+    // 7. Extract Authors
+    const authors: string[] = [];
+    const authorNodes = doc.find(
+      "//tei:TEI/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:biblStruct/tei:analytic/tei:author",
+      ns
+    );
+
+    for (const authorNode of authorNodes) {
+      const forenames: string[] = [];
+      // Get all forename nodes (type="first", type="middle")
+      const forenameNodes = authorNode.find("./tei:persName/tei:forename", ns);
+      for (const fNode of forenameNodes) {
+        // @ts-ignore
+        forenames.push(fNode.text().trim());
+      }
+      const surnameNode = authorNode.get("./tei:persName/tei:surname", ns);
+
+      if (forenames.length > 0 || surnameNode) {
+        const fullName =
+          // @ts-ignore
+          `${forenames.join(" ")} ${surnameNode ? surnameNode.text().trim() : ""}`.trim();
+        authors.push(fullName);
+      }
+    }
+
+    console.log(`[parseXml] Got ${authors.length} authors`);
 
     // Return the structured object
     return {
+      title,
       doi,
       abstract,
       introduction,
       methods,
       results,
       discussion,
+      conclusion,
+      futureWork,
+      appendix,
       citations,
+      authors,
+      datePublished,
+      publisher,
     };
   } catch (error) {
     console.error("Failed to parse XML or extract sections:", error);
     // Return an object indicating failure
     return {
+      title: null,
       doi: null,
       abstract: null,
       introduction: null,
       methods: null,
       results: null,
       discussion: null,
+      conclusion: null,
+      futureWork: null,
+      appendix: null,
       citations: null,
+      authors: null,
+      datePublished: null,
+      publisher: null,
       error: `Parsing failed: ${error.message}`,
     };
   }


### PR DESCRIPTION
- use science APIs (crossRef and semanticscholar) to retrieve the DOI by using the title extracted
- use that one instead of the LLM generated one

- add description for extracted science terms based on paper content
 
- use crossRef, semanticScholar, opencitations to get all references by DOI
- alongside the LLM generated ones, add these which should be factually correct considering they come from official APIs

- use ontology APIs to verify that the LLM-generated terms actually exist and correspond to the ontologies (most of the ontologies aside of GO were hallucinated previously in most cases) e.g. of new structure:
<img width="745" alt="image" src="https://github.com/user-attachments/assets/53f5fc54-e993-4d52-ac9f-971a719a071f" />
